### PR TITLE
Add storybook for profile page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,22 +1,26 @@
-import React, { useState } from 'react';
-import { BrowserRouter, Route, Routes } from 'react-router-dom';
-import { Box, CssBaseline, useMediaQuery, useTheme } from '@mui/material';
+import React, { useState } from "react";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { Box, CssBaseline, useMediaQuery, useTheme } from "@mui/material";
 import {
   SchoolRounded,
   GarageRounded,
   CottageRounded,
   SoupKitchenRounded,
-} from '@mui/icons-material';
+  PersonRounded,
+  FaceRounded,
+  TodayRounded,
+  WcRounded,
+} from "@mui/icons-material";
 
-import dayjs from 'dayjs';
-import HomePage from './stories/Home/HomePage';
-import Profile from './stories/Profile/Profile';
-import { useGetVersionDetailsQuery } from './services/version';
-import NavigationDrawer from './stories/NavigationDrawer/NavigationDrawer';
+import dayjs from "dayjs";
+import HomePage from "./stories/Home/HomePage";
+import Profile from "./stories/Profile/Profile";
+import { useGetVersionDetailsQuery } from "./services/version";
+import NavigationDrawer from "./stories/NavigationDrawer/NavigationDrawer";
 
 const App = () => {
   const theme = useTheme();
-  const matchesSmOrLarger = useMediaQuery(theme.breakpoints.up('sm'));
+  const matchesSmOrLarger = useMediaQuery(theme.breakpoints.up("sm"));
   const { data, error, isLoading } = useGetVersionDetailsQuery();
   console.log(data, error, isLoading);
 
@@ -29,72 +33,130 @@ const App = () => {
     tags: [
       {
         id: 1,
-        title: 'Home items',
-        description: 'home related stuffs..',
-        to: '/',
+        title: "Home items",
+        description: "home related stuffs..",
+        to: "/",
         lastUpdatedAt: dayjs().toDate(),
-        lastUpdatedBy: 'dogs_with_kookie',
+        lastUpdatedBy: "dogs_with_kookie",
         icon: <CottageRounded />,
       },
       {
         id: 2,
-        title: 'Kitchen items',
-        description: 'Click to edit description',
-        to: '/kitchen',
+        title: "Kitchen items",
+        description: "Click to edit description",
+        to: "/kitchen",
         lastUpdatedAt: dayjs().toDate(),
-        lastUpdatedBy: 'johny1443',
+        lastUpdatedBy: "johny1443",
         icon: <SoupKitchenRounded />,
       },
       {
         id: 3,
-        title: 'Bedroom items',
-        description: 'Click to edit description',
-        to: '/school',
+        title: "Bedroom items",
+        description: "Click to edit description",
+        to: "/school",
         lastUpdatedAt: dayjs().toDate(),
-        lastUpdatedBy: 'dogs_with_kookie',
+        lastUpdatedBy: "dogs_with_kookie",
         icon: <SchoolRounded />,
       },
       {
         id: 4,
-        title: 'Garage items',
-        description: 'Click to edit description',
-        to: '/garage',
+        title: "Garage items",
+        description: "Click to edit description",
+        to: "/garage",
         lastUpdatedAt: dayjs().toDate(),
-        lastUpdatedBy: 'xxmariah_whitney_2009xx',
+        lastUpdatedBy: "xxmariah_whitney_2009xx",
         icon: <GarageRounded />,
       },
     ],
     categories: [
       {
         id: 1,
-        title: 'Pantry',
-        description: 'kitchen pantry shelf items',
-        to: '/categories',
+        title: "Pantry",
+        description: "kitchen pantry shelf items",
+        to: "/categories",
         lastUpdatedAt: dayjs().toDate(),
-        lastUpdatedBy: 'dogs_with_kookie',
+        lastUpdatedBy: "dogs_with_kookie",
       },
       {
         id: 2,
-        title: 'Cleaning Cupboard',
-        description: 'Cleaning supplies storage unit',
-        to: '/categories',
+        title: "Cleaning Cupboard",
+        description: "Cleaning supplies storage unit",
+        to: "/categories",
         lastUpdatedAt: dayjs().toDate(),
-        lastUpdatedBy: 'dogs_with_kookie',
+        lastUpdatedBy: "dogs_with_kookie",
       },
       {
         id: 3,
-        title: 'Laundry and Guest Closet',
-        description: 'Click to edit description',
-        to: '/categories',
+        title: "Laundry and Guest Closet",
+        description: "Click to edit description",
+        to: "/categories",
         lastUpdatedAt: dayjs().toDate(),
-        lastUpdatedBy: 'dogs_with_kookie',
+        lastUpdatedBy: "dogs_with_kookie",
       },
     ],
   };
 
+  const profileDetailsProps = {
+    firstname: {
+      label: "firstname",
+      name: "firstname",
+      value: "John",
+      required: true,
+      fullWidth: true,
+      icon: <PersonRounded />,
+      error: false,
+      errorMsg: "",
+      validators: [],
+    },
+    lastname: {
+      label: "lastname",
+      name: "lastname",
+      value: "Doe",
+      required: true,
+      fullWidth: true,
+      icon: <PersonRounded />,
+      error: false,
+      errorMsg: "",
+      validators: [],
+    },
+    username: {
+      label: "username",
+      name: "username",
+      value: "johnny_1996",
+      required: true,
+      fullWidth: true,
+      icon: <FaceRounded />,
+      error: false,
+      errorMsg: "",
+      validators: [],
+    },
+    dob: {
+      label: "dob",
+      name: "dob",
+      value: "1996/12/12",
+      required: true,
+      fullWidth: true,
+      icon: <TodayRounded />,
+      error: false,
+      errorMsg: "",
+      validators: [],
+    },
+    gender: {
+      label: "gender",
+      name: "gender",
+      value: "Prefer not to answer",
+      required: true,
+      fullWidth: true,
+      icon: <WcRounded />,
+      error: false,
+      errorMsg: "",
+      validators: [],
+    },
+  };
+
   return (
     <BrowserRouter>
-      <Box sx={{ display: 'flex' }}>
+      <Box sx={{ display: "flex" }}>
         <CssBaseline />
         <NavigationDrawer
           drawerOpen={drawerOpen}
@@ -105,16 +167,24 @@ const App = () => {
         />
         <Box sx={{ flexGrow: 1, p: 3 }}>
           <Routes>
-            <Route exact path='/' element={<HomePage />} />
+            <Route exact path="/" element={<HomePage />} />
             <Route
-              path='/tag'
+              path="/tag"
               element={<Box>list of tag related stuffs here</Box>}
             />
             <Route
-              path='/categories'
+              path="/categories"
               element={<Box>list of category related stuff here</Box>}
             />
-            <Route path='/profile' element={<Profile />} />
+            <Route
+              path="/profile"
+              element={
+                <Profile
+                  categories={navigationDrawerProps.categories}
+                  profileDetails={profileDetailsProps}
+                />
+              }
+            />
           </Routes>
         </Box>
       </Box>

--- a/src/stories/Categories/EditCategoryDetails.jsx
+++ b/src/stories/Categories/EditCategoryDetails.jsx
@@ -1,0 +1,99 @@
+import { makeStyles } from 'tss-react/mui';
+import React, { useEffect, useState } from 'react';
+import { Box, Button, TextField } from '@mui/material';
+import { AddRounded, SaveRounded } from '@mui/icons-material';
+
+const useStyles = makeStyles()((theme) => {
+  return {
+    buttonContainer: {
+      display: 'flex',
+      flexDirection: 'row',
+      gap: theme.spacing(2),
+    },
+    container: {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(1),
+    },
+    fields: {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(2),
+    },
+    text: {
+      fontWeight: 'bold',
+      fontSize: '1.825rem',
+      fontFamily: 'Poppins, sans-serif',
+      color: theme.palette.common.black,
+      alignSelf: 'flex-start',
+    },
+  };
+});
+
+const EditCategoryDetails = ({ categories }) => {
+  const { classes } = useStyles();
+  const [formattedCategories, setFormattedCategories] = useState([]);
+
+  useEffect(() => {
+    if (Array.isArray(categories)) {
+      const draftCategories = categories.map((v) => ({
+        ...v,
+        fullWidth: true,
+        label: v.title,
+        name: v.title,
+        error: false,
+        errorMsg: '',
+        value: v.title,
+        placeholder: v.description,
+        required: false,
+        variant: 'standard',
+      }));
+      setFormattedCategories([...draftCategories]);
+    }
+  }, [categories]);
+
+  return (
+    <Box>
+      <Box className={classes.container}>
+        <Box className={classes.fields}>
+          {Object.values(formattedCategories).map((v, index) => (
+            <TextField
+              key={index}
+              className={classes.text}
+              fullWidth={v.fullWidth}
+              label={v.label}
+              name={v.name}
+              error={v.error}
+              placeholder={v.placeholder}
+              value={v.value}
+              required={v.required}
+              variant={v.variant}
+            />
+          ))}
+        </Box>
+        <Box className={classes.buttonContainer}>
+          {[
+            {
+              id: 1,
+              title: 'save',
+              onClick: () => {},
+              icon: <SaveRounded />,
+            },
+            {
+              id: 2,
+              title: 'Add Category',
+              onClick: () => {},
+              icon: <AddRounded />,
+            },
+          ].map((v) => (
+            <Button onClick={v.onClick()} endIcon={v.icon}>
+              {v.title}
+            </Button>
+          ))}
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export default EditCategoryDetails;

--- a/src/stories/Categories/EditCategoryDetails.stories.js
+++ b/src/stories/Categories/EditCategoryDetails.stories.js
@@ -1,0 +1,48 @@
+import dayjs from 'dayjs';
+import lightTheme from '../../theme';
+import { ThemeProvider } from '@mui/material';
+import EditCategoryDetails from './EditCategoryDetails';
+import { withRouter } from 'storybook-addon-react-router-v6';
+
+export default {
+  component: EditCategoryDetails,
+  decorators: [
+    withRouter,
+    (Story) => (
+      <ThemeProvider theme={lightTheme}>
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
+};
+
+export const PrimaryEditCategoryDetails = {
+  args: {
+    categories: [
+      {
+        id: 1,
+        title: 'Pantry',
+        description: 'kitchen pantry shelf items',
+        to: '/categories',
+        lastUpdatedAt: dayjs().toDate(),
+        lastUpdatedBy: 'dogs_with_kookie',
+      },
+      {
+        id: 2,
+        title: 'Cleaning Cupboard',
+        description: 'Cleaning supplies storage unit',
+        to: '/categories',
+        lastUpdatedAt: dayjs().toDate(),
+        lastUpdatedBy: 'dogs_with_kookie',
+      },
+      {
+        id: 3,
+        title: 'Laundry and Guest Closet',
+        description: 'Click to edit description',
+        to: '/categories',
+        lastUpdatedAt: dayjs().toDate(),
+        lastUpdatedBy: 'dogs_with_kookie',
+      },
+    ],
+  },
+};

--- a/src/stories/Categories/ViewCategoryDetails.jsx
+++ b/src/stories/Categories/ViewCategoryDetails.jsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import dayjs from 'dayjs';
+import {
+  Box,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+} from '@mui/material';
+import { makeStyles } from 'tss-react/mui';
+import * as relativeTime from 'dayjs/plugin/relativeTime';
+
+const useStyles = makeStyles()((theme) => {
+  return {
+    text: {
+      fontWeight: 'bold',
+      fontSize: '0.825rem',
+      color: theme.palette.common.black,
+      alignSelf: 'flex-start',
+    },
+  };
+});
+
+const ViewCategoryDetails = ({ tableCaption, categories }) => {
+  const { classes } = useStyles();
+  dayjs.extend(relativeTime);
+
+  return (
+    <Box>
+      {categories?.length > 0 ? (
+        <TableContainer component={Paper}>
+          <Table sx={{ minWidth: 650 }} aria-label='category details table'>
+            <caption>{tableCaption}</caption>
+            <TableHead>
+              <TableRow>
+                <TableCell className={classes.text}>Title</TableCell>
+                <TableCell className={classes.text} align='right'>
+                  Description
+                </TableCell>
+                <TableCell className={classes.text} align='right'>
+                  Last Updated At
+                </TableCell>
+                <TableCell className={classes.text} align='right'>
+                  Last Updated By
+                </TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {categories?.map((v, index) => (
+                <TableRow key={index}>
+                  <TableCell component='th' scope='row'>
+                    {v.title}
+                  </TableCell>
+                  <TableCell align='right'>{v?.description}</TableCell>
+                  <TableCell align='right'>
+                    {dayjs(v?.lastUpdatedAt).fromNow()}
+                  </TableCell>
+                  <TableCell align='right'>{v?.lastUpdatedBy}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      ) : null}
+    </Box>
+  );
+};
+
+export default ViewCategoryDetails;

--- a/src/stories/Categories/ViewCategoryDetails.stories.js
+++ b/src/stories/Categories/ViewCategoryDetails.stories.js
@@ -1,0 +1,49 @@
+import dayjs from "dayjs";
+import lightTheme from "../../theme";
+import { ThemeProvider } from "@mui/material";
+import ViewCategoryDetails from "./ViewCategoryDetails";
+import { withRouter } from "storybook-addon-react-router-v6";
+
+export default {
+  component: ViewCategoryDetails,
+  decorators: [
+    withRouter,
+    (Story) => (
+      <ThemeProvider theme={lightTheme}>
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
+};
+
+export const PrimaryViewCategoryDetails = {
+  args: {
+    tableCaption: "View list of categories",
+    categories: [
+      {
+        id: 1,
+        title: "Pantry",
+        description: "kitchen pantry shelf items",
+        to: "/categories",
+        lastUpdatedAt: dayjs().toDate(),
+        lastUpdatedBy: "dogs_with_kookie",
+      },
+      {
+        id: 2,
+        title: "Cleaning Cupboard",
+        description: "Cleaning supplies storage unit",
+        to: "/categories",
+        lastUpdatedAt: dayjs().toDate(),
+        lastUpdatedBy: "dogs_with_kookie",
+      },
+      {
+        id: 3,
+        title: "Laundry and Guest Closet",
+        description: "Click to edit description",
+        to: "/categories",
+        lastUpdatedAt: dayjs().toDate(),
+        lastUpdatedBy: "dogs_with_kookie",
+      },
+    ],
+  },
+};

--- a/src/stories/Heading/Heading.jsx
+++ b/src/stories/Heading/Heading.jsx
@@ -1,17 +1,19 @@
-import React from "react";
-import { Box } from "@mui/material";
-import { makeStyles } from "tss-react/mui";
-import HeadingTitle from "../HeadingTitle/HeadingTitle";
-import HeadingSubtitle from "../HeadingSubtitle/HeadingSubtitle";
+import React from 'react';
+import { makeStyles } from 'tss-react/mui';
+import { Box, IconButton } from '@mui/material';
+import HeadingTitle from '../HeadingTitle/HeadingTitle';
+import HeadingSubtitle from '../HeadingSubtitle/HeadingSubtitle';
 
 const useStyles = makeStyles()((theme) => {
   return {
     container: {
-      display: "flex",
-      flexDirection: "row",
+      display: 'flex',
+      flexDirection: 'row',
+      justifyContent: 'space-between',
     },
-    root: {
-      padding: theme.spacing(0.1, 1),
+    icon: {
+      width: theme.spacing(4),
+      height: theme.spacing(4),
     },
   };
 });
@@ -22,18 +24,27 @@ const Heading = ({
   titleVariant,
   subtitleVariant,
   gutterBottom,
+  editMode,
+  handleEditMode,
+  editIconPrimary,
+  editIconSecondary,
 }) => {
   const { classes } = useStyles();
 
   return (
     <Box className={classes.container}>
-      <Box className={classes.root}>
+      <Box>
         <HeadingTitle title={title} titleVariant={titleVariant} />
         <HeadingSubtitle
           text={subtitle}
           subtitleVariant={subtitleVariant}
           gutterBottom={gutterBottom}
         />
+      </Box>
+      <Box>
+        <IconButton onClick={handleEditMode} className={classes.icon}>
+          {editMode ? editIconSecondary : editIconPrimary}
+        </IconButton>
       </Box>
     </Box>
   );

--- a/src/stories/Heading/Heading.stories.js
+++ b/src/stories/Heading/Heading.stories.js
@@ -1,6 +1,6 @@
-import Heading from "./Heading";
-import { defaultTheme } from "../../theme";
-import { ThemeProvider } from "@mui/material";
+import Heading from './Heading';
+import { defaultTheme } from '../../theme';
+import { ThemeProvider } from '@mui/material';
 
 export default {
   component: Heading,
@@ -15,7 +15,10 @@ export default {
 
 export const PrimaryHeading = {
   args: {
-    title: "Climate",
-    subtitle: "Simple Inventory Management",
+    title: 'Climate',
+    subtitle: 'Simple Inventory Management',
+    titleVariant: 'h3',
+    subtitleVariant: 'caption',
+    gutterBottom: true,
   },
 };

--- a/src/stories/HeadingSubtitle/HeadingSubtitle.jsx
+++ b/src/stories/HeadingSubtitle/HeadingSubtitle.jsx
@@ -1,12 +1,11 @@
-import React from "react";
-import { makeStyles } from "tss-react/mui";
-import { Typography } from "@mui/material";
+import React from 'react';
+import { makeStyles } from 'tss-react/mui';
+import { Typography } from '@mui/material';
 
 const useStyles = makeStyles()((theme) => {
   return {
     root: {
-      fontSize: "0.725rem",
-      color: theme.palette.titleTextPrimary.main,
+      fontSize: '0.725rem',
     },
   };
 });

--- a/src/stories/HeadingTitle/HeadingTitle.jsx
+++ b/src/stories/HeadingTitle/HeadingTitle.jsx
@@ -1,14 +1,13 @@
-import React from "react";
-import { makeStyles } from "tss-react/mui";
-import { Box, Typography } from "@mui/material";
+import React from 'react';
+import { makeStyles } from 'tss-react/mui';
+import { Box, Typography } from '@mui/material';
 
 const useStyles = makeStyles()((theme) => {
   return {
     root: {
-      fontWeight: "bold",
-      fontSize: "1.825rem",
-      fontFamily: "Poppins, sans-serif",
-      color: theme.palette.titleTextPrimary.main,
+      fontWeight: 'bold',
+      fontSize: '1.825rem',
+      fontFamily: 'Poppins, sans-serif',
       alignSelf: 'flex-start',
     },
   };

--- a/src/stories/NavigationDrawer/NavigationDrawer.jsx
+++ b/src/stories/NavigationDrawer/NavigationDrawer.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { makeStyles } from 'tss-react/mui';
-import MuiDrawer from '@mui/material/Drawer';
+
 import {
   Box,
   List,
@@ -12,38 +12,30 @@ import {
 } from '@mui/material';
 
 import Heading from '../Heading/Heading';
+import MuiDrawer from '@mui/material/Drawer';
 import HeadingFilter from '../HeadingFilter/HeadingFilter';
 import HeadingToggle from '../HeadingToggle/HeadingToggle';
-import NavigationDrawerTitle from '../NavigationDrawerTitle/NavigationDrawerTitle';
-import NavigationDrawerListItem from '../NavigationDrawerListItem/NavigationDrawerListItem';
-
 import HeadingClosed from '../HeadingClosed/HeadingClosed';
 import { ArrowDropDownCircleRounded } from '@mui/icons-material';
+import NavigationDrawerTitle from '../NavigationDrawerTitle/NavigationDrawerTitle';
+import NavigationDrawerListItem from '../NavigationDrawerListItem/NavigationDrawerListItem';
 
 const drawerWidth = 300;
 
 const useStyles = makeStyles()((theme) => {
   return {
-    container: {
-      width: drawerWidth,
-      flexShrink: theme.spacing(0),
-      [`& .MuiDrawer-paper`]: {
-        width: drawerWidth,
-        boxSizing: 'border-box',
-      },
-    },
     accordion: {
       margin: theme.spacing(0),
       '&.Mui-expanded': {
         margin: theme.spacing(0),
       },
-      '& .MuiAccordion-root': {
+      '& .MuiAccordion-container': {
         '&.Mui-expanded': {
           margin: theme.spacing(0),
         },
       },
     },
-    root: {
+    container: {
       display: 'flex',
       alignItems: 'center',
       backgroundColor: theme.palette.secondary.main,
@@ -51,6 +43,13 @@ const useStyles = makeStyles()((theme) => {
       padding: theme.spacing(0, 1),
       // necessary for content to be below app bar
       ...theme.mixins.toolbar,
+    },
+    rootTitleContainer: {
+      display: 'flex',
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      gap: theme.spacing(2),
     },
     list: {
       padding: theme.spacing(0),
@@ -111,17 +110,9 @@ const NavigationDrawer = ({
   return (
     <>
       <Drawer variant={'permanent'} open={drawerOpen}>
-        <Box className={classes.root}>
+        <Box className={classes.container}>
           {drawerOpen ? (
-            <Box
-              sx={{
-                display: 'flex',
-                flexDirection: 'row',
-                justifyContent: 'space-between',
-                alignItems: 'center',
-                gap: 3,
-              }}
-            >
+            <Box className={classes.rootTitleContainer}>
               <Heading
                 title={'Climate'}
                 titleVariant={'h3'}

--- a/src/stories/NavigationDrawerListItem/NavigationDrawerListItem.stories.js
+++ b/src/stories/NavigationDrawerListItem/NavigationDrawerListItem.stories.js
@@ -26,7 +26,7 @@ export const PrimaryNavigationDrawerListItemDrawerOpen = {
       lastUpdatedBy: 'dogs_with_kookie',
       icon: <CottageRounded />,
     },
-    isCategory: true,
+    isCategory: false,
     drawerOpen: true,
   },
 };

--- a/src/stories/Profile/Profile.jsx
+++ b/src/stories/Profile/Profile.jsx
@@ -1,22 +1,92 @@
-import { Box, Button } from '@mui/material';
-import React from 'react';
+import React, { useState } from 'react';
+import { Box } from '@mui/material';
+import Heading from '../Heading/Heading';
+import { makeStyles } from 'tss-react/mui';
+import { CloseRounded, EditRounded } from '@mui/icons-material';
+import EditCategoryDetails from '../Categories/EditCategoryDetails';
+import ViewCategoryDetails from '../Categories/ViewCategoryDetails';
+import EditProfileDetails from '../ProfileDetails/EditProfileDetails';
+import ViewProfileDetails from '../ProfileDetails/ViewProfileDetails';
 
-const Profile = () => {
+const useStyles = makeStyles()((theme) => {
+  return {
+    container: {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(2),
+    },
+    itemContainer: {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(2),
+    },
+  };
+});
+
+const Profile = ({ profileDetails, categories }) => {
+  const { classes } = useStyles();
+
+  const [editProfileMode, setEditProfileMode] = useState(false);
+  const [editCategoriesMode, setEditCategoriesMode] = useState(false);
+
   return (
-    <Box>
-      Profile page
-      <h2>Edit Profile Details</h2>
-      <p>
-        Users are encouraged to signup or login. Users are responsible for
-        signing up / logging in. We display relevant information. Anonymous
-        users are not allowed to create or delete tags && categories.
-      </p>
-      <h2>Edit Categories</h2>
-      <p> wip on edit tag design </p>
-      <Button>Save</Button>
-      <Button>Cancel</Button>
-      <h2>Display Archieved categories here</h2>
-      <p> Sorry no matching records found if empty.</p>
+    <Box className={classes.container}>
+      <Box>
+        <Heading
+          title={'User details'}
+          titleVariant={'h3'}
+          subtitle={'Edit your personal information'}
+          subtitleVariant={'caption'}
+          gutterBottom={false}
+          editMode={editProfileMode}
+          handleEditMode={() => setEditProfileMode(!editProfileMode)}
+          editIconPrimary={<EditRounded />}
+          editIconSecondary={<CloseRounded />}
+        />
+        {editProfileMode ? (
+          <EditProfileDetails profileDetails={profileDetails} />
+        ) : (
+          <ViewProfileDetails profileDetails={profileDetails} />
+        )}
+      </Box>
+      <Box className={classes.itemContainer}>
+        <Heading
+          title={'Edit Categories'}
+          titleVariant={'h3'}
+          subtitle={'Create or edit existing categories'}
+          subtitleVariant={'caption'}
+          gutterBottom={true}
+          editMode={editCategoriesMode}
+          handleEditMode={() => setEditCategoriesMode(!editCategoriesMode)}
+          editIconPrimary={<EditRounded />}
+          editIconSecondary={<CloseRounded />}
+        />
+        {editCategoriesMode ? (
+          <EditCategoryDetails categories={categories} />
+        ) : (
+          <ViewCategoryDetails
+            categories={categories}
+            tableCaption={'List of categories'}
+            subtitleVariant={'caption'}
+          />
+        )}
+      </Box>
+      <Box className={classes.itemContainer}>
+        <Heading
+          title={'Archived Categories'}
+          titleVariant={'h3'}
+          gutterBottom={false}
+          subtitle={`${
+            categories.filter((v) => v.isArchived).length || 0
+          } archived categories`}
+          subtitleVariant={'caption'}
+        />
+        <ViewCategoryDetails
+          categories={categories}
+          tableCaption={'List of archived categories'}
+          subtitleVariant={'caption'}
+        />
+      </Box>
     </Box>
   );
 };

--- a/src/stories/Profile/Profile.stories.js
+++ b/src/stories/Profile/Profile.stories.js
@@ -1,12 +1,14 @@
-import Profile from './Profile';
-import lightTheme from '../../theme';
-import { ThemeProvider } from '@mui/material';
+import dayjs from "dayjs";
+import Profile from "./Profile";
+import { defaultTheme } from "../../theme";
+import { ThemeProvider } from "@mui/material";
+import { FaceRounded, PersonRounded, TodayRounded, WcRounded } from "@mui/icons-material";
 
 export default {
   component: Profile,
   decorators: [
     (Story) => (
-      <ThemeProvider theme={lightTheme}>
+      <ThemeProvider theme={defaultTheme}>
         <Story />
       </ThemeProvider>
     ),
@@ -14,5 +16,89 @@ export default {
 };
 
 export const PrimaryProfile = {
-  args: {},
+  args: {
+    profileDetails: {
+      firstname: {
+        label: "firstname",
+        name: "firstname",
+        value: "John",
+        required: true,
+        fullWidth: true,
+        icon: <PersonRounded />,
+        error: false,
+        errorMsg: "",
+        validators: [],
+      },
+      lastname: {
+        label: "lastname",
+        name: "lastname",
+        value: "Doe",
+        required: true,
+        fullWidth: true,
+        icon: <PersonRounded />,
+        error: false,
+        errorMsg: "",
+        validators: [],
+      },
+      username: {
+        label: "username",
+        name: "username",
+        value: "johnny_1996",
+        required: true,
+        fullWidth: true,
+        icon: <FaceRounded />,
+        error: false,
+        errorMsg: "",
+        validators: [],
+      },
+      dob: {
+        label: "dob",
+        name: "dob",
+        value: "1996/12/12",
+        required: true,
+        fullWidth: true,
+        icon: <TodayRounded />,
+        error: false,
+        errorMsg: "",
+        validators: [],
+      },
+      gender: {
+        label: "gender",
+        name: "gender",
+        value: "Prefer not to answer",
+        required: true,
+        fullWidth: true,
+        icon: <WcRounded />,
+        error: false,
+        errorMsg: "",
+        validators: [],
+      },
+    },
+    categories: [
+      {
+        id: 1,
+        title: "Pantry",
+        description: "kitchen pantry shelf items",
+        to: "/categories",
+        lastUpdatedAt: dayjs().toDate(),
+        lastUpdatedBy: "dogs_with_kookie",
+      },
+      {
+        id: 2,
+        title: "Cleaning Cupboard",
+        description: "Cleaning supplies storage unit",
+        to: "/categories",
+        lastUpdatedAt: dayjs().toDate(),
+        lastUpdatedBy: "dogs_with_kookie",
+      },
+      {
+        id: 3,
+        title: "Laundry and Guest Closet",
+        description: "Click to edit description",
+        to: "/categories",
+        lastUpdatedAt: dayjs().toDate(),
+        lastUpdatedBy: "dogs_with_kookie",
+      },
+    ],
+  },
 };

--- a/src/stories/ProfileDetails/EditProfileDetails.jsx
+++ b/src/stories/ProfileDetails/EditProfileDetails.jsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { makeStyles } from 'tss-react/mui';
+import { SaveRounded } from '@mui/icons-material';
+import { Box, InputAdornment, TextField, Button } from '@mui/material';
+
+const useStyles = makeStyles()((theme) => {
+  return {
+    buttonContainer: {
+      display: 'flex',
+      flexDirection: 'row',
+      gap: theme.spacing(2),
+    },
+    container: {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(1),
+    },
+    fields: {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(2),
+    },
+    text: {
+      fontWeight: 'bold',
+      fontSize: '1.825rem',
+      fontFamily: 'Poppins, sans-serif',
+      color: theme.palette.common.black,
+      alignSelf: 'flex-start',
+    },
+  };
+});
+
+const EditProfileDetails = ({ profileDetails }) => {
+  const { classes } = useStyles();
+
+  return (
+    <Box className={classes.container}>
+      <Box className={classes.fields}>
+        {Object.values(profileDetails).map((v) => (
+          <TextField
+            key={v.name}
+            className={classes.text}
+            fullWidth={v.fullWidth}
+            label={v.label}
+            name={v.name}
+            error={v.error}
+            placeholder={v.label}
+            value={v.value}
+            required={v.required}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position='start'>{v.icon}</InputAdornment>
+              ),
+            }}
+          />
+        ))}
+      </Box>
+      <Box className={classes.buttonContainer}>
+        {[
+          {
+            id: 1,
+            title: 'save',
+            onClick: () => {},
+            icon: <SaveRounded />,
+          },
+        ].map((v) => (
+          <Button onClick={v.onClick()} endIcon={v.icon}>
+            {v.title}
+          </Button>
+        ))}
+      </Box>
+    </Box>
+  );
+};
+
+export default EditProfileDetails;

--- a/src/stories/ProfileDetails/EditProfileDetails.stories.js
+++ b/src/stories/ProfileDetails/EditProfileDetails.stories.js
@@ -1,0 +1,82 @@
+import lightTheme from '../../theme';
+import { ThemeProvider } from '@mui/material';
+import EditProfileDetails from './EditProfileDetails';
+import {
+  FaceRounded,
+  PersonRounded,
+  TodayRounded,
+  WcRounded,
+} from '@mui/icons-material';
+
+export default {
+  component: EditProfileDetails,
+  decorators: [
+    (Story) => (
+      <ThemeProvider theme={lightTheme}>
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
+};
+
+export const PrimaryEditProfileDetails = {
+  args: {
+    profileDetails: {
+      firstname: {
+        label: 'firstname',
+        name: 'firstname',
+        value: 'John',
+        required: true,
+        fullWidth: true,
+        icon: <PersonRounded />,
+        error: false,
+        errorMsg: '',
+        validators: [],
+      },
+      lastname: {
+        label: 'lastname',
+        name: 'lastname',
+        value: 'Doe',
+        required: true,
+        fullWidth: true,
+        icon: <PersonRounded />,
+        error: false,
+        errorMsg: '',
+        validators: [],
+      },
+      username: {
+        label: 'username',
+        name: 'username',
+        value: 'johnny_1996',
+        required: true,
+        fullWidth: true,
+        icon: <FaceRounded />,
+        error: false,
+        errorMsg: '',
+        validators: [],
+      },
+      dob: {
+        label: 'dob',
+        name: 'dob',
+        value: '1996/12/12',
+        required: true,
+        fullWidth: true,
+        icon: <TodayRounded />,
+        error: false,
+        errorMsg: '',
+        validators: [],
+      },
+      gender: {
+        label: 'gender',
+        name: 'gender',
+        value: 'Prefer not to answer',
+        required: true,
+        fullWidth: true,
+        icon: <WcRounded />,
+        error: false,
+        errorMsg: '',
+        validators: [],
+      },
+    },
+  },
+};

--- a/src/stories/ProfileDetails/ViewProfileDetails.jsx
+++ b/src/stories/ProfileDetails/ViewProfileDetails.jsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { makeStyles } from 'tss-react/mui';
+import { Avatar, Box, InputAdornment, TextField } from '@mui/material';
+
+const useStyles = makeStyles()((theme) => {
+  return {
+    container: {
+      display: 'flex',
+      flexDirection: 'row',
+      gap: theme.spacing(2),
+      [theme.breakpoints.down('sm')]: {
+        display: 'flex',
+        flexDirection: 'column',
+      },
+    },
+    avatarContainer: {
+      minHeight: theme.spacing(40),
+      minWidth: theme.spacing(30),
+      backgroundColor: theme.palette.grey[300],
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    avatar: {
+      height: theme.spacing(20),
+      width: theme.spacing(20),
+    },
+    darkerText: {
+      fontWeight: 'bold',
+      fontSize: '0.825rem',
+      color: theme.palette.common.black,
+      alignSelf: 'flex-start',
+    },
+    fields: {
+      display: 'flex',
+      gap: theme.spacing(2),
+      flexWrap: 'wrap',
+    },
+  };
+});
+
+const ViewProfileDetails = ({ profileDetails }) => {
+  const { classes } = useStyles();
+
+  return (
+    <Box className={classes.container}>
+      <Box className={classes.avatarContainer}>
+        <Avatar title='MP' className={classes.avatar} />
+      </Box>
+      <Box className={classes.fields}>
+        {Object.values(profileDetails).map((v) => (
+          <TextField
+            key={v.name}
+            className={classes.text}
+            fullWidth={v.fullWidth}
+            label={v.label}
+            name={v.name}
+            error={v.error}
+            placeholder={v.label}
+            value={v.value}
+            required={v.required}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position='start'>{v.icon}</InputAdornment>
+              ),
+            }}
+          />
+        ))}
+      </Box>
+    </Box>
+  );
+};
+
+export default ViewProfileDetails;

--- a/src/stories/ProfileDetails/ViewProfileDetails.stories.js
+++ b/src/stories/ProfileDetails/ViewProfileDetails.stories.js
@@ -1,0 +1,82 @@
+import lightTheme from '../../theme';
+import { ThemeProvider } from '@mui/material';
+import ViewProfileDetails from './ViewProfileDetails';
+import {
+  FaceRounded,
+  PersonRounded,
+  TodayRounded,
+  WcRounded,
+} from '@mui/icons-material';
+
+export default {
+  component: ViewProfileDetails,
+  decorators: [
+    (Story) => (
+      <ThemeProvider theme={lightTheme}>
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
+};
+
+export const PrimaryViewProfileDetails = {
+  args: {
+    profileDetails: {
+      firstname: {
+        label: 'firstname',
+        name: 'firstname',
+        value: 'John',
+        required: true,
+        fullWidth: true,
+        icon: <PersonRounded />,
+        error: false,
+        errorMsg: '',
+        validators: [],
+      },
+      lastname: {
+        label: 'lastname',
+        name: 'lastname',
+        value: 'Doe',
+        required: true,
+        fullWidth: true,
+        icon: <PersonRounded />,
+        error: false,
+        errorMsg: '',
+        validators: [],
+      },
+      username: {
+        label: 'username',
+        name: 'username',
+        value: 'johnny_1996',
+        required: true,
+        fullWidth: true,
+        icon: <FaceRounded />,
+        error: false,
+        errorMsg: '',
+        validators: [],
+      },
+      dob: {
+        label: 'dob',
+        name: 'dob',
+        value: '1996/12/12',
+        required: true,
+        fullWidth: true,
+        icon: <TodayRounded />,
+        error: false,
+        errorMsg: '',
+        validators: [],
+      },
+      gender: {
+        label: 'gender',
+        name: 'gender',
+        value: 'Prefer not to answer',
+        required: true,
+        fullWidth: true,
+        icon: <WcRounded />,
+        error: false,
+        errorMsg: '',
+        validators: [],
+      },
+    },
+  },
+};


### PR DESCRIPTION
- add storybook for profile page
- profile page currently consists of three section, userdetails and
  edit, categories and edit, archived categories and no edit.
- still unclear about tags and edit.
- added storybook for all major layout with samples.
- added sample user data in app.js file
- adds category details in profile page
- adds profile page details
- adds category in profile page
- adds archived categories in profile page
- add storybook for profile heading section
- add storybook for profile section
- add ability to view title section for each of the profile page
  elements
- add section for edit categories and archived categories
- add extra buttons for saving and / or creating new categories
- add ability to save profile changes
- added avatar and edit profile section
- streamlined heading section and heading subtitle section
- added profile.jsx and editProfile.stories.js file
- added viewProfileDetails.jsx and its storybook file